### PR TITLE
A few tweaks in the Readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Installation
 _Note: Not fully compatible with MySQL-Kanboard environments due to the field limit_
 
 **_or_**
-- git clone (_or ftp upload_) and extract the zip into this folder: `.\plugins\KanboardCSS\` (must be exact case)
+- git clone (_or ftp upload_) and extract the zip into this folder: `./plugins/KanboardCSS/` (must be exact case)
 
 
 Authors & Contributors

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Installation
   - Open Kanboard: `Settings` -> `Plugins` -> `Plugin Directory`
 
 **_or_**
-- Copy data from `style.css`
+- Copy data from `kanboardcss.css`
   - Open Kanboard: `Settings` -> `Application Settings`
   - Paste in `Custom Stylesheet`
   - Save

--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ Installation
 _Note: Not fully compatible with MySQL-Kanboard environments due to the field limit_
 
 **_or_**
+- Copy the file `kanboardcss.css` to folder `./plugins/Customizer/Assets/css/themes` when using the plugin Customizer
+
+**_or_**
 - git clone (_or ftp upload_) and extract the zip into this folder: `./plugins/KanboardCSS/` (must be exact case)
 
 


### PR DESCRIPTION
All changes affects the installation section.

- corrected the file name style-css to kanboardcss.css
- added installation instructions for users of the plugin Customizer
- changed the directory separator chars from `\` to `/` (it is the common separator in a HTTP-server-environment)