### PR TITLE
Fix: added selector a:focus to the definition of a:hover

### DIFF
--- a/kanboardcss.css
+++ b/kanboardcss.css
@@ -205,6 +205,7 @@ body {
 }
 
 /* mouse over link */
+    a:focus,
     a:hover {
     color: rgb(128, 128, 128);
 }


### PR DESCRIPTION
This is important for keyboard users, as they should share the experience of mouse users. The look should be the same for focusing a link as when one is hovering the link with the mouse cursor.

At the moment the highlighting of a focused link follows the rules of a browsers own stylesheet. This means, it gets a focus ring (i.e. a solid outline in Firefox) only. In earlier browser versions it was typically an inconspicuous dotted line. So the focused link is spottable in general. On the other side, without the equal rules as for `:hover` a focussed link has no change in text colour that a hovered link has. This is an *unnecessary limitation* because a changing colour is an additional highlighter and makes it easier to spot the focused element for the sighted audience.